### PR TITLE
Change max size from 15000 to 6000

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ const getImages = async () => {
         url = url.replace("ProofWatermark=TRUE", "ProofWatermark=FALSE");
         if (!ids.includes(id)) {
             ids.push(id);
-            url = url.replace("MaxSize=400", "MaxSize=15000");
+            url = url.replace("MaxSize=400", "MaxSize=6000");
             const res = await fetch(url);
             const imageBlob = await res.blob();
             photozip.file(id + '.jfif', imageBlob, {binary: true});


### PR DESCRIPTION
Changing the max size would allow the image download to be quicker and file sizes to be smaller.

6000px is chosen from the Tempest FAQs which allow an image to be printed at A2 at 300dpi.

https://www.htempest.co.uk/faqs/schools-faqs